### PR TITLE
(MAINT) Add google analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem 'jekyll-analytics', github: 'hendrikschneider/jekyll-analytics', branch: 'master'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/hendrikschneider/jekyll-analytics.git
+  revision: 8b57cd569b4fddfbcc3b0b0c816c1fa31383a288
+  branch: master
+  specs:
+    jekyll-analytics (0.1.12)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -246,6 +253,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-analytics!
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,12 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-analytics
+
+jekyll_analytics:
+  GoogleAnalytics:
+    id: UA-157301458-1
+    anonymizeIp: true
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
This commit adds google analytics tracking with IP
anonymization turned on for the static site. This
complies with GDPR and enables us to collect metrics
and info about the project.